### PR TITLE
Use shared settings in toplevel Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
 ]
 
 [workspace.package]
+version = "0.1.0"
 edition = "2021"
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ members = [
   "c-infra",
   "c-presentation"
 ]
+
+[workspace.package]
+edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,14 @@ members = [
 
 [workspace.package]
 edition = "2021"
+
+[workspace.dependencies]
+anyhow = "1.0"
+chrono = "0.4"
+derive-new = "0.5"
+futures = "0.3"
+itertools = "0.10"
+regex = "1.6"
+strum = { version = "0.24", features = ["derive"] }
+test-case = "2.2"
+tokio = { version = "1.21", features = ["macros", "rt", "rt-multi-thread"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 ### Builder ###
-FROM clux/muslrust:1.63.0 AS chef
+# TODO: clux/muslrust haven't released 1.64.0 yet, so use nightly build
+FROM clux/muslrust:1.64.0-nightly-2022-08-06 AS chef
 RUN cargo install cargo-chef
 WORKDIR /app
 

--- a/c-domain/Cargo.toml
+++ b/c-domain/Cargo.toml
@@ -7,11 +7,12 @@ edition.workspace = true
 mock = ["mockall"]
 
 [dependencies]
-anyhow = "1.0"
+anyhow.workspace = true
+chrono.workspace = true
+derive-new.workspace = true
+
 async-trait = "0.1"
-derive-new = "0.5"
 strum = { version = "0.24", features = ["derive"] }
-chrono = "0.4"
 mockall = {version = "0.11", optional = true}
 
 [dev-dependencies]

--- a/c-domain/Cargo.toml
+++ b/c-domain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c-domain"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 
 [features]

--- a/c-domain/Cargo.toml
+++ b/c-domain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c-domain"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 [features]
 mock = ["mockall"]

--- a/c-infra/Cargo.toml
+++ b/c-infra/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c-infra"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/c-infra/Cargo.toml
+++ b/c-infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c-infra"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/c-infra/Cargo.toml
+++ b/c-infra/Cargo.toml
@@ -9,17 +9,18 @@ edition.workspace = true
 c-domain = { path = "../c-domain" }
 crate-shared = { path = "../crate-shared" }
 
+anyhow.workspace = true
+chrono.workspace = true
+derive-new.workspace = true
+itertools.workspace = true
+strum.workspace = true
+
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-chrono = "0.4"
 async-trait = "0.1"
-anyhow = "1.0"
-derive-new = "0.5"
-itertools = "0.10"
 surf = "2.3"
-strum = "0.24"
 create-github-app-token = "2.0.0"
 
 [dev-dependencies]
-test-case = "2.2"
-tokio = { version = "1.21", features = ["rt", "macros"] }
+test-case.workspace = true
+tokio.workspace = true

--- a/c-presentation/Cargo.toml
+++ b/c-presentation/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c-presentation"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/c-presentation/Cargo.toml
+++ b/c-presentation/Cargo.toml
@@ -11,17 +11,18 @@ c-usecase = { path = "../c-usecase" }
 c-infra = { path = "../c-infra" }
 crate-shared = { path = "../crate-shared" }
 
+anyhow.workspace = true
+chrono.workspace = true
+derive-new.workspace = true
+futures.workspace = true
+itertools.workspace = true
+regex.workspace = true
+strum.workspace = true
+tokio.workspace = true
+
 once_cell = "1.15"
-anyhow = "1.0"
-tokio = { version = "1.21", features = ["macros", "rt-multi-thread"] }
-futures = "0.3"
-itertools = "0.10"
-chrono = "0.4"
 fern = "0.6"
 log = "0.4"
 poise = "0.3"
-derive-new = "0.5"
-regex = "1.6"
-strum = { version = "0.24", features = ["derive"] }
 argh = "0.1"
 thiserror = "1.0"

--- a/c-presentation/Cargo.toml
+++ b/c-presentation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c-presentation"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/c-usecase/Cargo.toml
+++ b/c-usecase/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c-usecase"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/c-usecase/Cargo.toml
+++ b/c-usecase/Cargo.toml
@@ -9,15 +9,15 @@ edition.workspace = true
 c-domain = { path = "../c-domain" }
 crate-shared = { path = "../crate-shared" }
 
-anyhow = "1.0"
-derive-new = "0.5"
-chrono = "0.4"
-regex = "1.6"
-futures = "0.3"
+anyhow.workspace = true
+chrono.workspace = true
+derive-new.workspace = true
+futures.workspace = true
+regex.workspace = true
 
 [dev-dependencies]
 c-domain = { path = "../c-domain", features = ["mock"] }
 
-itertools = "0.10"
-test-case = "2.2"
-tokio = { version = "1.21", features = ["rt", "macros"] }
+itertools.workspace = true
+test-case.workspace = true
+tokio.workspace = true

--- a/c-usecase/Cargo.toml
+++ b/c-usecase/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c-usecase"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crate-shared/Cargo.toml
+++ b/crate-shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crate-shared"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crate-shared/Cargo.toml
+++ b/crate-shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crate-shared"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
- chore(Dockerfile): use 1.64.0 muslrust
- chore(Cargo.toml): use workspace shared edition
- chore(Cargo.toml): use workspace shared deps
- chore(Cargo.toml): use workspace shared crate version
